### PR TITLE
Update index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 Welcome to Part B Structured Project's documentation!
-===========================================
+=====================================================
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
I think it's annoyingly this simple!

From what you sent, I saw "WARNING: Title underline too short."  And, [this line in the config file](https://github.com/codiewood/BSP_Project/blob/0303dc90cf15e4d2f44c3511f7677e8c1e6efda4/.readthedocs.yml#L14) tells Read the Docs to treat a warning as an error.